### PR TITLE
Create the output directory for Game.js before writing

### DIFF
--- a/rags2html.py
+++ b/rags2html.py
@@ -1908,6 +1908,7 @@ async def process_file(fpath, keys, args, progress=None):
                 copy_function=copy_missing)
 
         out_path = os.path.join(out_dir, 'regalia', 'game', 'Game.js')
+        os.makedirs(os.path.dirname(out_path), exist_ok=True)
         with open(out_path, 'wt') as out:
             out.write(game_js)
 


### PR DESCRIPTION
When running rags2html.py locally (Python 3.13), a FileNotFoundError is raised at line 1911 during conversion as the regalia\game directory does not exist when trying to write Game.js

Add a one-liner (works in Python 3.2+) for directory creation before writing.